### PR TITLE
Add fixed-price-path and fixed-rate pricing modes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -196,5 +196,5 @@ codebase.md
 
 # Custom folders
 examples/outputs/
-docs/
+docs/dev/
 scripts/

--- a/README.md
+++ b/README.md
@@ -196,6 +196,7 @@ The suite has three tiers:
 | 1 — Component isolation | `test_data_handler.py`, `test_auction.py`, `test_industrial.py`, `test_emissions.py`, `test_price_response.py`, `test_stockpile.py`, `test_forestry.py`, `test_calculation_engine.py` | Each supply/demand component in isolation with synthetic data | ~25 s |
 | 2 — Integration | `test_integration.py` | Full model runs; structural invariants and regression values | ~5 min |
 | 3 — API contracts | `test_api_contracts.py` | User-facing workflow: error handling, method chaining, multi-scenario | ~1 min |
+| 3 — Pricing modes | `test_pricing_modes.py` | `set_mode()`, `fixed_path`, and `fixed_rate` pricing modes; optimised mode unchanged | ~3 min |
 
 ### Test fixtures
 

--- a/examples/05_fixed_price_runs.ipynb
+++ b/examples/05_fixed_price_runs.ipynb
@@ -1,0 +1,388 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "a1b2c3d4",
+   "metadata": {},
+   "source": [
+    "# Fixed Price Runs: `fixed_path` and `fixed_rate` pricing modes\n",
+    "\n",
+    "By default, NZUpy **optimises** the price change rate to find the carbon price path that balances supply and demand. However, we can also use two alternative pricing modes that skip the optimiser entirely:\n",
+    "\n",
+    "| Mode | What it does |\n",
+    "|---|---|\n",
+    "| `optimised` | Default — finds the price growth rate that clears the market with minimal difference between supply and demand from start to end year |\n",
+    "| `fixed_path` | User supplies an explicit year-by-year price series |\n",
+    "| `fixed_rate` | User supplies a scalar annual growth rate; prices grow from the 2024 starting price at that rate |\n",
+    "\n",
+    "These modes are useful for:\n",
+    "- **Sensitivity analysis**: hold the price fixed and study how supply/demand components respond\n",
+    "- **Policy scenarios**: model the effect of an explicit price scenario (e.g., Climate Change Commission price path)\n",
+    "- **Comparison runs**: contrast emissions impacts and stockpile dynamics under different price path assumptions\n",
+    "\n",
+    "Pricing modes are set via `set_mode()` and price data is supplied via `fill()`."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b2c3d4e5",
+   "metadata": {},
+   "source": [
+    "## 1. Setup"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c3d4e5f6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "import plotly.graph_objects as go\n",
+    "from pathlib import Path\n",
+    "import sys\n",
+    "import os\n",
+    "\n",
+    "# Add project root to path\n",
+    "project_root = Path().absolute().parent\n",
+    "sys.path.insert(0, str(project_root))\n",
+    "\n",
+    "from model.core.base_model import NZUpy\n",
+    "\n",
+    "data_dir = project_root / \"data\"\n",
+    "output_dir = project_root / \"examples\" / \"outputs\" / \"05_fixed_price_runs\"\n",
+    "os.makedirs(output_dir, exist_ok=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d4e5f6a7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Initialise model with three scenarios\n",
+    "NZU = NZUpy(data_dir=data_dir)\n",
+    "NZU.define_time(2024, 2050)\n",
+    "NZU.define_scenarios(['Optimised', 'Fixed Path', 'Fixed Rate'])\n",
+    "NZU.allocate()\n",
+    "NZU.fill_defaults()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e5f6a7b8",
+   "metadata": {},
+   "source": [
+    "## 2. Fixed price path (`fixed_path`)\n",
+    "\n",
+    "Supply a year-by-year price series that the model will use directly.\n",
+    "\n",
+    "Here we define a simple linear path rising from \\$50 to \\$90 over the modelling period."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f6a7b8c9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "years = NZU.years  # 2024–2050\n",
+    "\n",
+    "# Linear price path: $50 in 2024, +$1.54/yr to reach ~$90 in 2050\n",
+    "price_path = pd.Series(\n",
+    "    {y: 50.0 + (y - 2024) * (90.0 - 50.0) / (2050 - 2024) for y in range(2024, 2051)}\n",
+    ")\n",
+    "\n",
+    "print(\"Price path (first 5 years):\")\n",
+    "print(price_path.head().round(2))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a7b8c9d0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Set fixed_path mode and supply the price series\n",
+    "NZU.set_mode('pricing_mode', 'fixed_path', scenario='Fixed Path')\n",
+    "NZU.fill('price_path', price_path, scenario='Fixed Path')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b8c9d0e1",
+   "metadata": {},
+   "source": [
+    "## 3. Fixed price change rate (`fixed_rate`)\n",
+    "\n",
+    "Supply a single annual growth rate. Prices grow from the model's 2024 starting price at this rate each year.\n",
+    "\n",
+    "Here we use 3% per year."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c9d0e1f2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Set fixed_rate mode and supply the growth rate\n",
+    "NZU.set_mode('pricing_mode', 'fixed_rate', scenario='Fixed Rate')\n",
+    "NZU.fill('price_change_rate', 0.03, scenario='Fixed Rate')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d0e1f2a3",
+   "metadata": {},
+   "source": [
+    "## 4. Run all three scenarios"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e1f2a3b4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "results = NZU.run()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f2a3b4c5",
+   "metadata": {},
+   "source": [
+    "## 5. Results: price trajectories\n",
+    "\n",
+    "Let's compare the three price paths."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a3b4c5d6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Extract prices for model years from each scenario\n",
+    "prices_opt    = NZU.results['Optimised']['prices'].loc[years]\n",
+    "prices_fp     = NZU.results['Fixed Path']['prices'].loc[years]\n",
+    "prices_fr     = NZU.results['Fixed Rate']['prices'].loc[years]\n",
+    "\n",
+    "print(f\"{'Year':>6}  {'Optimised':>12}  {'Fixed Path':>12}  {'Fixed Rate':>12}\")\n",
+    "print(\"-\" * 50)\n",
+    "for y in years[::5]:  # every 5th year\n",
+    "    print(f\"{y:>6}  {prices_opt[y]:>12.2f}  {prices_fp[y]:>12.2f}  {prices_fr[y]:>12.2f}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b4c5d6e7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# 3-way comparison chart\n",
+    "fig = go.Figure()\n",
+    "\n",
+    "fig.add_trace(go.Scatter(\n",
+    "    x=list(years), y=prices_opt.tolist(),\n",
+    "    name='Optimised', mode='lines',\n",
+    "    line=dict(color='#1f77b4', width=2)\n",
+    "))\n",
+    "fig.add_trace(go.Scatter(\n",
+    "    x=list(years), y=prices_fp.tolist(),\n",
+    "    name='Fixed Path ($50→$90 linear)', mode='lines',\n",
+    "    line=dict(color='#ff7f0e', width=2, dash='dash')\n",
+    "))\n",
+    "fig.add_trace(go.Scatter(\n",
+    "    x=list(years), y=prices_fr.tolist(),\n",
+    "    name='Fixed Rate (3% p.a.)', mode='lines',\n",
+    "    line=dict(color='#2ca02c', width=2, dash='dot')\n",
+    "))\n",
+    "\n",
+    "fig.update_layout(\n",
+    "    title='Carbon price comparison: Optimised vs Fixed modes',\n",
+    "    xaxis_title='Year',\n",
+    "    yaxis_title='NZU price (2023 NZD / tCO₂-e)',\n",
+    "    template='plotly_white',\n",
+    "    legend=dict(x=0.02, y=0.98)\n",
+    ")\n",
+    "fig.show()\n",
+    "fig.write_image(str(output_dir / 'price_comparison.png'))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c5d6e7f8",
+   "metadata": {},
+   "source": [
+    "## 6. Results: supply–demand balance under fixed prices\n",
+    "\n",
+    "When prices are fixed, the balance between supply and demand over the modelled period are no longer optimised. The gap is informative: it tells you whether the fixed price is above or below the market-clearing level."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d6e7f8a9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Supply–demand balance for each scenario\n",
+    "def get_balance(scenario_name):\n",
+    "    model_result = NZU.results[scenario_name]['model']\n",
+    "    supply_total = model_result['supply']['total'].loc[years]\n",
+    "    demand       = model_result['demand'].loc[years]\n",
+    "    return (supply_total - demand)\n",
+    "\n",
+    "balance_opt = get_balance('Optimised')\n",
+    "balance_fp  = get_balance('Fixed Path')\n",
+    "balance_fr  = get_balance('Fixed Rate')\n",
+    "\n",
+    "print(f\"{'Year':>6}  {'Optimised':>14}  {'Fixed Path':>14}  {'Fixed Rate':>14}\")\n",
+    "print(\"-\" * 58)\n",
+    "for y in years[::5]:\n",
+    "    print(f\"{y:>6}  {balance_opt[y]:>14,.0f}  {balance_fp[y]:>14,.0f}  {balance_fr[y]:>14,.0f}\")\n",
+    "print(\"\\n(positive = surplus; negative = shortage)\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e7f8a9b0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Supply–demand gap chart\n",
+    "fig2 = go.Figure()\n",
+    "\n",
+    "for label, bal, colour in [\n",
+    "    ('Optimised',               balance_opt, '#1f77b4'),\n",
+    "    ('Fixed Path ($50→$90)',    balance_fp,  '#ff7f0e'),\n",
+    "    ('Fixed Rate (3% p.a.)',    balance_fr,  '#2ca02c'),\n",
+    "]:\n",
+    "    fig2.add_trace(go.Scatter(\n",
+    "        x=list(years), y=(bal / 1000).tolist(),\n",
+    "        name=label, mode='lines', line=dict(color=colour, width=2)\n",
+    "    ))\n",
+    "\n",
+    "fig2.add_hline(y=0, line_dash='dash', line_color='grey', opacity=0.5)\n",
+    "\n",
+    "fig2.update_layout(\n",
+    "    title='Supply–demand balance by scenario',\n",
+    "    xaxis_title='Year',\n",
+    "    yaxis_title='Balance (Mt CO₂-e)',\n",
+    "    template='plotly_white',\n",
+    "    legend=dict(x=0.02, y=0.98)\n",
+    ")\n",
+    "fig2.show()\n",
+    "fig2.write_image(str(output_dir / 'supply_demand_balance.png'))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f8a9b0c1",
+   "metadata": {},
+   "source": [
+    "## 7. Use-case: government price commitment\n",
+    "\n",
+    "A common use-case is to model what happens if the government announces a specific price path — for instance, prices rising with a fixed nominal rate of 3% per year from the current NZU price.\n",
+    "\n",
+    "Below we show how to quickly set this up and extract the key output: **what stockpile drawdown does that price path imply?**"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a9b0c1d2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Stockpile balance under fixed_rate scenario\n",
+    "fr_stk_results  = NZU.results['Fixed Rate']['model']['stockpile_results']\n",
+    "opt_stk_results = NZU.results['Optimised']['model']['stockpile_results']\n",
+    "\n",
+    "fig3 = go.Figure()\n",
+    "for label, stk, colour in [\n",
+    "    ('Optimised',      opt_stk_results, '#1f77b4'),\n",
+    "    ('Fixed Rate 3%',  fr_stk_results,  '#2ca02c'),\n",
+    "]:\n",
+    "    fig3.add_trace(go.Scatter(\n",
+    "        x=list(years),\n",
+    "        y=(stk['stockpile_balance'].loc[years] / 1000).tolist(),\n",
+    "        name=label, mode='lines', line=dict(color=colour, width=2)\n",
+    "    ))\n",
+    "\n",
+    "fig3.add_hline(y=0, line_dash='dash', line_color='grey', opacity=0.5)\n",
+    "fig3.update_layout(\n",
+    "    title='Stockpile balance: Optimised vs Fixed Rate 3%',\n",
+    "    xaxis_title='Year',\n",
+    "    yaxis_title='Stockpile balance (Mt NZUs)',\n",
+    "    template='plotly_white'\n",
+    ")\n",
+    "fig3.show()\n",
+    "fig3.write_image(str(output_dir / 'stockpile_comparison.png'))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b0c1d2e3",
+   "metadata": {},
+   "source": [
+    "## Summary\n",
+    "\n",
+    "| Feature | `fixed_path` | `fixed_rate` | `optimised` |\n",
+    "|---|---|---|---|\n",
+    "| Price source | User-supplied pd.Series | User-supplied scalar growth rate | Solved by optimiser |\n",
+    "| Supply–demand balance | Not enforced | Not enforced | Enforced (gap → 0) |\n",
+    "| `price_change_rate` in result | `None` | User-supplied rate | Solved rate |\n",
+    "| `total_gap` in result | `None` | `None` | ~0 |\n",
+    "| Main use | Policy commitment, sensitivity | Rule-based scenarios | Market clearing |\n",
+    "\n",
+    "### API recap\n",
+    "\n",
+    "```python\n",
+    "# fixed_path\n",
+    "nzu.set_mode('pricing_mode', 'fixed_path', scenario='MyScenario')\n",
+    "nzu.fill('price_path', my_series, scenario='MyScenario')\n",
+    "\n",
+    "# fixed_rate\n",
+    "nzu.set_mode('pricing_mode', 'fixed_rate', scenario='MyScenario')\n",
+    "nzu.fill('price_change_rate', 0.05, scenario='MyScenario')\n",
+    "\n",
+    "nzu.run()\n",
+    "```"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "venv (3.12.6)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/model/config.py
+++ b/model/config.py
@@ -82,3 +82,8 @@ class ComponentConfig:
     forestry_discount_rate: Optional[float] = None
     forestry_forward_years: Optional[int] = None
 
+    # Pricing mode settings
+    pricing_mode: str = 'optimised'             # 'optimised' | 'fixed_path' | 'fixed_rate'
+    price_path: Optional[object] = None         # pd.Series of prices, used when pricing_mode='fixed_path'
+    price_change_rate: Optional[float] = None   # scalar rate, used when pricing_mode='fixed_rate'
+

--- a/model/core/base_model.py
+++ b/model/core/base_model.py
@@ -304,6 +304,19 @@ class NZUpy:
         # Price
         'start_price': 'price',
         'price_control': 'price',
+        # Pricing mode
+        'pricing_mode': 'pricing',
+        'price_path': 'pricing',
+        'price_change_rate': 'pricing',
+    }
+
+    # Mode switches: name → tuple of valid values
+    _MODE_OPTIONS = {
+        'forestry_mode':             ('exogenous', 'endogenous'),
+        'pricing_mode':              ('optimised', 'fixed_path', 'fixed_rate'),
+        'penalise_shortfalls':       (True, False),
+        'manley_sensitivity':        ('low', 'central', 'high'),
+        'forestry_price_assumption': ('future', 'current'),
     }
 
     def fill_defaults(self, config: str = 'central') -> 'NZUpy':
@@ -444,6 +457,13 @@ class NZUpy:
                 "Model must be allocated before filling. Call allocate() first."
             )
 
+        # Inform the user when they pass a mode variable through fill()
+        if variable_name in self._MODE_OPTIONS:
+            print(
+                f"Note: '{variable_name}' is a mode switch. "
+                f"Consider using set_mode('{variable_name}', ...) instead."
+            )
+
         # Resolve component
         if component is None:
             if variable_name not in self._VARIABLE_COMPONENT_MAP:
@@ -516,6 +536,27 @@ class NZUpy:
                 if not isinstance(value, int) or value not in [1, 2]:
                     raise ValueError("demand_model_number must be 1 or 2")
                 self.component_configs[i].demand_model_number = value
+            elif component == 'pricing':
+                if variable_name == 'pricing_mode':
+                    if value not in self._MODE_OPTIONS['pricing_mode']:
+                        raise ValueError(
+                            f"pricing_mode must be one of "
+                            f"{list(self._MODE_OPTIONS['pricing_mode'])}, got '{value}'"
+                        )
+                    self.component_configs[i].pricing_mode = value
+                elif variable_name == 'price_path':
+                    if not isinstance(value, pd.Series):
+                        raise ValueError("price_path must be a pd.Series")
+                    self.component_configs[i].price_path = value
+                elif variable_name == 'price_change_rate':
+                    if not isinstance(value, (int, float)):
+                        raise ValueError("price_change_rate must be a number")
+                    self.component_configs[i].price_change_rate = float(value)
+                else:
+                    raise ValueError(
+                        f"Unknown pricing variable: '{variable_name}'. "
+                        f"Valid options: pricing_mode, price_path, price_change_rate"
+                    )
             elif isinstance(value, pd.Series):
                 self._store_series(variable_name, value, component=component, scenario_index=i)
             else:
@@ -548,6 +589,74 @@ class NZUpy:
             nzu.run()
         """
         return self.scenario_manager.configure_range_scenarios()
+
+    def set_mode(
+        self,
+        mode_name: str,
+        value,
+        scenario: Optional[Union[str, int]] = None,
+    ) -> 'NZUpy':
+        """
+        Set a structural mode switch for one or all scenarios.
+
+        Use this for categorical model behaviour switches (e.g. pricing_mode,
+        forestry_mode). For data values use fill().
+
+        Args:
+            mode_name: Mode to set — one of 'pricing_mode', 'forestry_mode',
+                       'penalise_shortfalls', 'manley_sensitivity',
+                       'forestry_price_assumption'.
+            value: New value. Must be one of the valid options for the mode.
+            scenario: Scenario name or index. If None, applies to ALL scenarios.
+
+        Returns:
+            Self for method chaining.
+
+        Example:
+            nzu.set_mode('pricing_mode', 'fixed_path', scenario='Alt')
+            nzu.set_mode('forestry_mode', 'endogenous')   # all scenarios
+        """
+        if not self._primed:
+            raise ValueError(
+                "Model must be allocated before setting modes. Call allocate() first."
+            )
+
+        if mode_name not in self._MODE_OPTIONS:
+            raise ValueError(
+                f"Unknown mode '{mode_name}'. "
+                f"Valid modes: {list(self._MODE_OPTIONS.keys())}"
+            )
+        if value not in self._MODE_OPTIONS[mode_name]:
+            raise ValueError(
+                f"Invalid value '{value}' for mode '{mode_name}'. "
+                f"Valid options: {list(self._MODE_OPTIONS[mode_name])}"
+            )
+
+        # Resolve scenario index(es)
+        if scenario is None:
+            indices = list(range(len(self.scenarios)))
+        elif isinstance(scenario, int):
+            if scenario < 0 or scenario >= len(self.scenarios):
+                raise ValueError(
+                    f"Scenario index {scenario} out of range "
+                    f"(0–{len(self.scenarios) - 1})."
+                )
+            indices = [scenario]
+        else:
+            if scenario not in self.scenarios:
+                raise ValueError(
+                    f"Unknown scenario: '{scenario}'. "
+                    f"Available: {', '.join(self.scenarios)}"
+                )
+            indices = [self.scenarios.index(scenario)]
+
+        for i in indices:
+            setattr(self.component_configs[i], mode_name, value)
+
+        scope = (f"scenario '{self.scenarios[indices[0]]}'"
+                 if len(indices) == 1 else "all scenarios")
+        print(f"Set {mode_name}='{value}' for {scope}.")
+        return self
 
     # -------------------------------------------------------------------------
     # Discoverability methods
@@ -587,7 +696,7 @@ class NZUpy:
         variables = self._COMPONENT_VARIABLES.get(component, [])
 
         print(f"\nAvailable configs for '{component}':")
-        print(f"  Configs  : {available}")
+        print(f"  Configs: {available}")
         print(f"  Variables: {variables}")
 
         return {var: available for var in variables}

--- a/model/core/runner.py
+++ b/model/core/runner.py
@@ -173,8 +173,9 @@ class ModelRunner:
             component_config = self.model.component_configs[self.model._active_scenario_index]
             self.model.scenario_manager._initialise_scenario_components(component_config, scenario_name)
         
-        # CRITICAL FIX: Explicitly calculate prices WITH price controls
-        self.model.calculation_engine._calculate_initial_prices()
+        # Calculate initial prices — skipped for fixed_path (prices already injected)
+        if not self._is_fixed_path_active():
+            self.model.calculation_engine._calculate_initial_prices()
         
         # Set up the model run
         run_data = self._initialise_model_run()
@@ -241,11 +242,11 @@ class ModelRunner:
             # Update stockpile usage for next iteration
             run_data['stockpile_usage'] = new_stockpile_usage
         
-        # IMPORTANT: After last iteration, recalculate prices once more
-        # to ensure price controls are properly applied
+        # After last iteration, recalculate prices to apply price controls —
+        # skipped for fixed_path (user-supplied prices must not be overwritten)
         if run_data['iteration'] >= run_data['max_iterations'] or run_data['converged']:
-            # Force recalculation of prices with controls
-            self.model.calculation_engine._calculate_initial_prices()
+            if not self._is_fixed_path_active():
+                self.model.calculation_engine._calculate_initial_prices()
     
     def _perform_single_iteration(self, scenario_name: Optional[str] = None) -> Tuple[Dict[str, pd.Series], pd.Series, pd.Series]:
         """
@@ -257,30 +258,46 @@ class ModelRunner:
         Returns:
             Tuple of (stockpile_results, previous_prices, new_stockpile_usage)
         """
-        # Calculate initial prices based on the price change rate
-        self.model.calculation_engine._calculate_initial_prices()
-        
+        # Calculate initial prices — skipped for fixed_path (prices already injected)
+        if not self._is_fixed_path_active():
+            self.model.calculation_engine._calculate_initial_prices()
+
         # Calculate demand based on current prices
         self.model.calculation_engine._calculate_demand()
-        
+
         # Calculate base supply (without stockpile) using scenario-specific data
         self.model.calculation_engine._calculate_base_supply(scenario_name)
-        
+
         # Calculate supply-demand balance
         stockpile_results = self._calculate_stockpile_contribution()
-        
+
+        # Store on model so _calculate_supply can access it (needed when the
+        # optimiser has not previously run, e.g. fixed_rate / fixed_path modes)
+        if isinstance(stockpile_results, dict):
+            stockpile_results = pd.DataFrame(stockpile_results)
+        self.model.stockpile_results = stockpile_results
+
         # Get new stockpile usage and previous prices for convergence check
         new_stockpile_usage = stockpile_results['available_units'].copy()
         prev_prices = self.model.prices.copy()
-        
-        # Revise prices based on stockpile usage
-        self.model.calculation_engine._revise_prices_based_on_stockpile(stockpile_results)
+
+        # Revise prices based on stockpile usage — skipped for fixed_path
+        # (user-supplied prices must not be modified by internal logic)
+        if not self._is_fixed_path_active():
+            self.model.calculation_engine._revise_prices_based_on_stockpile(stockpile_results)
         
         # Calculate final supply (including stockpile) using scenario-specific data
         self.model.calculation_engine._calculate_supply(scenario_name)
         
         return stockpile_results, prev_prices, new_stockpile_usage
     
+    def _is_fixed_path_active(self) -> bool:
+        """Return True if the active scenario is in fixed_path pricing mode."""
+        idx = getattr(self.model, '_active_scenario_index', None)
+        if idx is None:
+            return False
+        return getattr(self.model.component_configs[idx], 'pricing_mode', 'optimised') == 'fixed_path'
+
     def _calculate_stockpile_contribution(self) -> Dict[str, pd.Series]:
         """
         Calculate the stockpile contribution based on supply-demand balance.
@@ -433,17 +450,25 @@ class ModelRunner:
         # Store active scenario index and name for parameter lookups
         self.model._active_scenario_index = scenario_index
         self.model._active_scenario_name = scenario_name
-        
+
         # Initialize price control for this scenario
         self.model._initialise_price_control()
-        
-        # Run optimisation for this scenario
-        result = self._run_scenario_optimisation(scenario_name)
-        
+
+        # Branch on pricing mode
+        component_config = self.model.component_configs[scenario_index]
+        pricing_mode = getattr(component_config, 'pricing_mode', 'optimised')
+
+        if pricing_mode == 'fixed_path':
+            result = self._run_fixed_path(scenario_name, scenario_index)
+        elif pricing_mode == 'fixed_rate':
+            result = self._run_fixed_rate(scenario_name, scenario_index)
+        else:
+            result = self._run_scenario_optimisation(scenario_name)
+
         # Clear active scenario info
         self.model._active_scenario_index = None
         self.model._active_scenario_name = None
-        
+
         return result
 
     def _run_scenario_optimisation(self, scenario_name: str) -> Dict[str, Any]:
@@ -470,6 +495,76 @@ class ModelRunner:
         # Compile and return results
         return self._compile_optimisation_results(optimisation_results, gap, model_results)
     
+    def _run_fixed_path(self, scenario_name: str, scenario_index: int) -> Dict[str, Any]:
+        """
+        Run a scenario with a user-supplied price series (no optimisation).
+
+        Prices are injected directly from component_config.price_path.
+        """
+        component_config = self.model.component_configs[scenario_index]
+        price_path = getattr(component_config, 'price_path', None)
+        if price_path is None:
+            raise ValueError(
+                f"pricing_mode='fixed_path' requires a price series. "
+                f"Call fill('price_path', series, scenario='{scenario_name}') first."
+            )
+
+        # Inject the user-supplied prices into the model's price series
+        for year in self.model.calculation_years:
+            if year in price_path.index:
+                self.model.prices[year] = price_path[year]
+            elif self.model.years and year > max(self.model.years):
+                # Extend beyond model end using last supplied price
+                last_year = max(y for y in price_path.index if y <= max(self.model.years))
+                self.model.prices[year] = price_path[last_year]
+
+        # Run forward calculation with rate=0 (prices already set, guard skips recalculation)
+        self.model.price_change_rate = 0.0
+        model_results = self.run_model(0.0, scenario_name=scenario_name, is_final_run=True)
+
+        return {
+            'price_change_rate': None,
+            'total_gap': None,
+            'prices': model_results['prices'],
+            'unmodified_prices': model_results.get('unmodified_prices', model_results['prices']),
+            'supply': model_results['supply'],
+            'demand': model_results['demand'],
+            'final_price': model_results['prices'][self.model.config.end_year],
+            'convergence_success': True,
+            'optimisation_message': 'fixed_path — no optimisation',
+            'model': model_results,
+        }
+
+    def _run_fixed_rate(self, scenario_name: str, scenario_index: int) -> Dict[str, Any]:
+        """
+        Run a scenario with a user-supplied price change rate (no optimisation).
+
+        The rate is read from component_config.price_change_rate.
+        """
+        component_config = self.model.component_configs[scenario_index]
+        rate = getattr(component_config, 'price_change_rate', None)
+        if rate is None:
+            raise ValueError(
+                f"pricing_mode='fixed_rate' requires a price change rate. "
+                f"Call fill('price_change_rate', value, scenario='{scenario_name}') first."
+            )
+
+        self.model.price_change_rate = rate
+        model_results = self.run_model(rate, scenario_name=scenario_name, is_final_run=True)
+
+        return {
+            'price_change_rate': rate,
+            'total_gap': None,
+            'prices': model_results['prices'],
+            'unmodified_prices': model_results.get('unmodified_prices', model_results['prices']),
+            'supply': model_results['supply'],
+            'demand': model_results['demand'],
+            'final_price': model_results['prices'][self.model.config.end_year],
+            'convergence_success': True,
+            'optimisation_message': 'fixed_rate — no optimisation',
+            'model': model_results,
+        }
+
     def _setup_optimiser(self) -> FastSolveOptimiser:
         """
         Set up the optimiser with appropriate configuration.

--- a/model/core/scenario_manager.py
+++ b/model/core/scenario_manager.py
@@ -386,9 +386,9 @@ class ScenarioManager:
         from model.demand.emissions import EmissionsDemand
         from model.demand.price_response import PriceResponse
         
-        # Initialize components with proper error handling
+        # Initialise components with proper error handling
         try:
-            # Initialize StockpileSupply with proper parameters from config
+            # Initialise StockpileSupply with proper parameters from config
             self.model.stockpile = StockpileSupply(
                 years=self.model.years,
                 extended_years=getattr(self.model, 'extended_years', None),

--- a/tests/test_pricing_modes.py
+++ b/tests/test_pricing_modes.py
@@ -1,0 +1,249 @@
+"""
+Tests for set_mode(), fixed_path pricing, and fixed_rate pricing.
+
+Test categories:
+  - set_mode() validation
+  - fixed_path mode: prices injected, no optimisation
+  - fixed_rate mode: user-supplied rate, no optimisation
+  - Default (optimised) mode unchanged
+  - fill() prints a note for mode variables
+"""
+
+import pytest
+import pandas as pd
+import numpy as np
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def allocated_model(test_data_dir):
+    """Allocated but not yet filled — used to test set_mode validation."""
+    from model.core.base_model import NZUpy
+    nzu = NZUpy(data_dir=test_data_dir)
+    nzu.define_time(2024, 2035)
+    nzu.define_scenarios(["S1", "S2"])
+    nzu.allocate()
+    return nzu
+
+
+@pytest.fixture
+def filled_model(test_data_dir):
+    """Fully filled model ready to run — 3 scenarios for mode comparison."""
+    from model.core.base_model import NZUpy
+    nzu = NZUpy(data_dir=test_data_dir)
+    nzu.define_time(2024, 2035)
+    nzu.define_scenarios(["Optimised", "FixedPath", "FixedRate"])
+    nzu.allocate()
+    nzu.fill_defaults()
+    return nzu
+
+
+@pytest.fixture
+def price_path_series():
+    """A simple fixed price path for 2024–2035."""
+    return pd.Series({y: 50.0 + (y - 2024) * 2 for y in range(2024, 2036)})
+
+
+# ---------------------------------------------------------------------------
+# set_mode() validation
+# ---------------------------------------------------------------------------
+
+class TestSetModeValidation:
+    def test_unknown_mode_raises(self, allocated_model):
+        with pytest.raises(ValueError, match="Unknown mode"):
+            allocated_model.set_mode("nonexistent_mode", "value")
+
+    def test_invalid_value_raises(self, allocated_model):
+        with pytest.raises(ValueError, match="Invalid value"):
+            allocated_model.set_mode("pricing_mode", "banana")
+
+    def test_valid_pricing_mode_accepted(self, allocated_model):
+        allocated_model.set_mode("pricing_mode", "fixed_path", scenario="S1")
+        assert allocated_model.component_configs[0].pricing_mode == "fixed_path"
+
+    def test_valid_forestry_mode_accepted(self, allocated_model):
+        allocated_model.set_mode("forestry_mode", "endogenous", scenario="S1")
+        assert allocated_model.component_configs[0].forestry_mode == "endogenous"
+
+    def test_all_scenarios_default(self, allocated_model):
+        allocated_model.set_mode("pricing_mode", "fixed_rate")
+        assert all(c.pricing_mode == "fixed_rate" for c in allocated_model.component_configs)
+
+    def test_single_scenario_by_name(self, allocated_model):
+        allocated_model.set_mode("pricing_mode", "fixed_path", scenario="S2")
+        assert allocated_model.component_configs[0].pricing_mode == "optimised"
+        assert allocated_model.component_configs[1].pricing_mode == "fixed_path"
+
+    def test_single_scenario_by_index(self, allocated_model):
+        allocated_model.set_mode("pricing_mode", "fixed_path", scenario=0)
+        assert allocated_model.component_configs[0].pricing_mode == "fixed_path"
+        assert allocated_model.component_configs[1].pricing_mode == "optimised"
+
+    def test_invalid_scenario_name_raises(self, allocated_model):
+        with pytest.raises(ValueError, match="Unknown scenario"):
+            allocated_model.set_mode("pricing_mode", "fixed_path", scenario="NoSuch")
+
+    def test_invalid_scenario_index_raises(self, allocated_model):
+        with pytest.raises(ValueError):
+            allocated_model.set_mode("pricing_mode", "fixed_path", scenario=99)
+
+    def test_before_allocate_raises(self, test_data_dir):
+        from model.core.base_model import NZUpy
+        nzu = NZUpy(data_dir=test_data_dir)
+        nzu.define_time(2024, 2035)
+        nzu.define_scenarios(["S1"])
+        with pytest.raises(ValueError, match="allocate"):
+            nzu.set_mode("pricing_mode", "optimised")
+
+    def test_returns_self_for_chaining(self, allocated_model):
+        result = allocated_model.set_mode("pricing_mode", "optimised")
+        assert result is allocated_model
+
+
+# ---------------------------------------------------------------------------
+# fixed_path mode
+# ---------------------------------------------------------------------------
+
+class TestFixedPathMode:
+    def test_fixed_path_runs_without_error(self, filled_model, price_path_series):
+        filled_model.set_mode("pricing_mode", "fixed_path", scenario="FixedPath")
+        filled_model.fill("price_path", price_path_series, scenario="FixedPath")
+        filled_model.run()
+
+    def test_fixed_path_prices_match_supplied_series(self, filled_model, price_path_series):
+        filled_model.set_mode("pricing_mode", "fixed_path", scenario="FixedPath")
+        filled_model.fill("price_path", price_path_series, scenario="FixedPath")
+        filled_model.run()
+
+        result_prices = filled_model.results["FixedPath"]["prices"]
+        for year in range(2024, 2036):
+            assert abs(result_prices[year] - price_path_series[year]) < 0.01, (
+                f"Year {year}: expected {price_path_series[year]}, got {result_prices[year]}"
+            )
+
+    def test_fixed_path_result_has_expected_keys(self, filled_model, price_path_series):
+        filled_model.set_mode("pricing_mode", "fixed_path", scenario="FixedPath")
+        filled_model.fill("price_path", price_path_series, scenario="FixedPath")
+        filled_model.run()
+        result = filled_model.results["FixedPath"]
+        assert "prices" in result
+        assert "supply" in result
+        assert "demand" in result
+        assert result["total_gap"] is None
+        assert result["price_change_rate"] is None
+
+    def test_fixed_path_missing_series_raises(self, filled_model):
+        filled_model.set_mode("pricing_mode", "fixed_path", scenario="FixedPath")
+        # Don't supply price_path
+        with pytest.raises(ValueError, match="price_path"):
+            filled_model.run()
+
+    def test_fixed_path_does_not_affect_other_scenarios(self, filled_model, price_path_series):
+        """Optimised scenario should still run normally."""
+        filled_model.set_mode("pricing_mode", "fixed_path", scenario="FixedPath")
+        filled_model.fill("price_path", price_path_series, scenario="FixedPath")
+        filled_model.run()
+        opt_result = filled_model.results["Optimised"]
+        assert opt_result["price_change_rate"] is not None
+
+
+# ---------------------------------------------------------------------------
+# fixed_rate mode
+# ---------------------------------------------------------------------------
+
+class TestFixedRateMode:
+    def test_fixed_rate_runs_without_error(self, filled_model):
+        filled_model.set_mode("pricing_mode", "fixed_rate", scenario="FixedRate")
+        filled_model.fill("price_change_rate", 0.05, scenario="FixedRate")
+        filled_model.run()
+
+    def test_fixed_rate_result_has_expected_keys(self, filled_model):
+        filled_model.set_mode("pricing_mode", "fixed_rate", scenario="FixedRate")
+        filled_model.fill("price_change_rate", 0.05, scenario="FixedRate")
+        filled_model.run()
+        result = filled_model.results["FixedRate"]
+        assert "prices" in result
+        assert "supply" in result
+        assert "demand" in result
+        assert result["total_gap"] is None
+        assert result["price_change_rate"] == pytest.approx(0.05)
+
+    def test_fixed_rate_missing_rate_raises(self, filled_model):
+        filled_model.set_mode("pricing_mode", "fixed_rate", scenario="FixedRate")
+        with pytest.raises(ValueError, match="price_change_rate"):
+            filled_model.run()
+
+    def test_fixed_rate_zero_gives_flat_prices(self, filled_model):
+        filled_model.set_mode("pricing_mode", "fixed_rate", scenario="FixedRate")
+        filled_model.fill("price_change_rate", 0.0, scenario="FixedRate")
+        filled_model.run()
+        result_prices = filled_model.results["FixedRate"]["prices"]
+        model_years = filled_model.years
+        first = result_prices[model_years[0]]
+        for year in model_years[1:]:
+            assert abs(result_prices[year] - first) < 0.01, (
+                f"Expected flat prices but year {year} differs from {model_years[0]}"
+            )
+
+    def test_fixed_rate_different_rates_give_different_prices(self, filled_model):
+        """Two runs with different rates produce different end prices."""
+        from model.core.base_model import NZUpy
+
+        def run_with_rate(data_dir, rate):
+            nzu = NZUpy(data_dir=data_dir)
+            nzu.define_time(2024, 2035)
+            nzu.define_scenarios(["S"])
+            nzu.allocate()
+            nzu.fill_defaults()
+            nzu.set_mode("pricing_mode", "fixed_rate")
+            nzu.fill("price_change_rate", rate)
+            nzu.run()
+            return nzu.results["S"]["prices"][2035]
+
+        data_dir = filled_model.data_handler.data_dir
+        price_low = run_with_rate(data_dir, 0.01)
+        price_high = run_with_rate(data_dir, 0.10)
+        assert price_high > price_low
+
+
+# ---------------------------------------------------------------------------
+# Default (optimised) mode unchanged
+# ---------------------------------------------------------------------------
+
+class TestOptimisedModeUnchanged:
+    def test_default_pricing_mode_is_optimised(self, allocated_model):
+        for cfg in allocated_model.component_configs:
+            assert cfg.pricing_mode == "optimised"
+
+    def test_optimised_run_produces_non_none_price_change_rate(self, basic_model):
+        basic_model.run()
+        result = basic_model.results["Test"]
+        assert result["price_change_rate"] is not None
+
+    def test_optimised_run_prices_positive(self, basic_model):
+        basic_model.run()
+        result = basic_model.results["Test"]
+        assert all(result["prices"][y] > 0 for y in basic_model.years)
+
+
+# ---------------------------------------------------------------------------
+# fill() note for mode variables
+# ---------------------------------------------------------------------------
+
+class TestFillModeNote:
+    def test_fill_pricing_mode_prints_note(self, allocated_model, capsys):
+        allocated_model.fill("pricing_mode", "optimised", scenario="S1")
+        captured = capsys.readouterr()
+        assert "set_mode" in captured.out
+
+    def test_fill_forestry_mode_prints_note(self, allocated_model, capsys):
+        allocated_model.fill("forestry_mode", "exogenous", scenario="S1")
+        captured = capsys.readouterr()
+        assert "set_mode" in captured.out
+
+    def test_fill_pricing_mode_still_sets_value(self, allocated_model):
+        allocated_model.fill("pricing_mode", "fixed_rate", scenario="S1")
+        assert allocated_model.component_configs[0].pricing_mode == "fixed_rate"


### PR DESCRIPTION
- Add set_mode() API method for structural mode switches (pricing_mode, forestry_mode, penalise_shortfalls, manley_sensitivity, etc.)
- Add pricing_mode='fixed_path': user supplies year-by-year price series via fill('price_path', pd.Series(...)); optimiser is skipped
- Add pricing_mode='fixed_rate': user supplies scalar price change rate via fill('price_change_rate', rate); optimiser is skipped
- Update ComponentConfig with pricing_mode, price_path, price_change_rate fields
- Add _run_fixed_path() and _run_fixed_rate() to runner.py
- Add example notebook 05_fixed_price_runs.ipynb
- Add tests/test_pricing_modes.py covering all three pricing modes